### PR TITLE
Fix the occurrence order of attributes.

### DIFF
--- a/HtmlBuilder.Test/BasicTest.cs
+++ b/HtmlBuilder.Test/BasicTest.cs
@@ -1,3 +1,5 @@
+#pragma warning disable SA1118
+
 namespace Maroontress.Html.Test
 {
     using System;
@@ -76,6 +78,20 @@ namespace Maroontress.Html.Test
             Check(
                 custom.WithId("e"),
                 "<custom id=\"e\">");
+            Check(
+                custom.AddAttributes(("name1", null), ("name2", null)),
+                "<custom name1 name2>");
+            Check(
+                custom.AddEmptyAttributes("name1", "name2"),
+                "<custom name1 name2>");
+            Check(
+                custom.AddAttributes(
+                    ("name1", "1"),
+                    ("name2", null),
+                    ("name3", "3"),
+                    ("name4", null),
+                    ("name5", "5")),
+                "<custom name1=\"1\" name2 name3=\"3\" name4 name5=\"5\">");
             CommonAttributeTest(custom);
         }
 
@@ -107,6 +123,23 @@ namespace Maroontress.Html.Test
             Check(
                 custom.WithId("e"),
                 "<custom id=\"e\"></custom>");
+            Check(
+                custom.AddAttributes(("name1", null), ("name2", null)),
+                "<custom name1 name2></custom>");
+            Check(
+                custom.AddEmptyAttributes("name1", "name2"),
+                "<custom name1 name2></custom>");
+            Check(
+                custom
+                    .AddAttributes(
+                        ("name1", "1"),
+                        ("name2", null))
+                    .AddAttributes(
+                        ("name3", "3"),
+                        ("name4", null),
+                        ("name5", "5")),
+                "<custom name1=\"1\" name2 name3=\"3\" name4 name5=\"5\">"
+                + "</custom>");
             CommonAttributeTest(custom);
         }
 

--- a/HtmlBuilder.Test/ExampleTest.cs
+++ b/HtmlBuilder.Test/ExampleTest.cs
@@ -37,6 +37,20 @@ namespace Maroontress.Html.Test
         }
 
         [TestMethod]
+        public void EmptyAttribute()
+        {
+            var nodeOf = Nodes.NewFactory();
+            var div = nodeOf.Div
+                .Add(nodeOf.Input.AddEmptyAttributes("disabled"))
+                .Add(nodeOf.Button.AddAttributes(("disabled", null)));
+            var result = div.ToString();
+
+            Assert.AreEqual(
+                "<div><input disabled><button disabled></button></div>",
+                result);
+        }
+
+        [TestMethod]
         public void IdAndClass()
         {
             var nodeOf = Nodes.NewFactory();

--- a/HtmlBuilder/HtmlBuilder.ruleset
+++ b/HtmlBuilder/HtmlBuilder.ruleset
@@ -80,6 +80,7 @@
     <Rule Id="SA1513" Action="None" />
     <Rule Id="SA1002" Action="None" />
     <Rule Id="SA1314" Action="None" />
+    <Rule Id="SA1600" Action="None" />
   </Rules>
   <Rules AnalyzerId="StyleChecker" RuleNamespace="StyleChecker">
     <Rule Id="EqualsNull" Action="Warning" />

--- a/HtmlBuilder/Maroontress/Html/AttributeData.cs
+++ b/HtmlBuilder/Maroontress/Html/AttributeData.cs
@@ -1,0 +1,25 @@
+namespace Maroontress.Html
+{
+    /// <summary>
+    /// The attribute data.
+    /// </summary>
+    public interface AttributeData
+    {
+        /// <summary>
+        /// Gets the occurrence order. Zero means the first attribute of the
+        /// element.
+        /// </summary>
+        int Order { get; }
+
+        /// <summary>
+        /// Gets the attribute's name.
+        /// </summary>
+        string Name { get; }
+
+        /// <summary>
+        /// Gets the attribute's value. If the value is <c>null</c>, this
+        /// represents the empty attribute.
+        /// </summary>
+        string? Value { get; }
+    }
+}

--- a/HtmlBuilder/Maroontress/Html/BaseTag.cs
+++ b/HtmlBuilder/Maroontress/Html/BaseTag.cs
@@ -61,12 +61,41 @@ namespace Maroontress.Html
         /// attribute that has the specified value.
         /// </summary>
         /// <param name="attributes">
-        /// Tuples of the name and value representing an attribute.
+        /// Tuples of the name and value representing an attribute. If the
+        /// value of the tuple is <c>null</c>, it represents the empty
+        /// attribute.
         /// </param>
         /// <returns>
         /// The new <see cref="BaseTag{T}"/> object.
         /// </returns>
         [return: DoNotIgnore]
-        T AddAttributes(params (string name, string value)[] attributes);
+        T AddAttributes(params (string name, string? value)[] attributes);
+
+        /// <summary>
+        /// Gets a new <see cref="BaseTag{T}"/> object with the specified empty
+        /// attribute.
+        /// </summary>
+        /// <param name="attributeNames">
+        /// The name of the empty attribute.
+        /// </param>
+        /// <returns>
+        /// The new <see cref="BaseTag{T}"/> object.
+        /// </returns>
+        /// <remarks>
+        /// <para>An invocation of this method of the form
+        /// <c>tag.AddEmptyAttributes(n1, n2)</c> behaves in exactly the same
+        /// way as the invocation <c>tag.AddAttributes((n1, null), (n2,
+        /// null))</c>.</para>
+        ///
+        /// <para>The web browser interprets the value of
+        /// the empty attribute as the empty string implicitly. So, for
+        /// example, <c>&lt;input disabled&gt;</c> is equivalent to
+        /// <c>&lt;input disabled=""&gt;</c>. The former can be generated with
+        /// <c>AddEmptyAttributes("disabled")</c> or
+        /// <c>AddAttributes(("disabled", null))</c>, and the latter with
+        /// <c>AddAttributes(("disabled", ""))</c>.</para>
+        /// </remarks>
+        [return: DoNotIgnore]
+        T AddEmptyAttributes(params string[] attributeNames);
     }
 }

--- a/HtmlBuilder/Maroontress/Html/Impl/AttributeDataImpl.cs
+++ b/HtmlBuilder/Maroontress/Html/Impl/AttributeDataImpl.cs
@@ -1,0 +1,36 @@
+namespace Maroontress.Html.Impl
+{
+    /// <summary>
+    /// The default implementation of an <see cref="AttributeData"/>.
+    /// </summary>
+    public sealed class AttributeDataImpl : AttributeData
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AttributeDataImpl"/>
+        /// class.
+        /// </summary>
+        /// <param name="order">
+        /// The occurrence order.
+        /// </param>
+        /// <param name="attribute">
+        /// The tuple containing the name and value of the attribute. If the
+        /// value is <c>null</c>, this represents the empty attribute.
+        /// </param>
+        public AttributeDataImpl(
+            int order, (string name, string? value) attribute)
+        {
+            Order = order;
+            Name = attribute.name;
+            Value = attribute.value;
+        }
+
+        /// <inheritdoc/>
+        public int Order { get; }
+
+        /// <inheritdoc/>
+        public string Name { get; }
+
+        /// <inheritdoc/>
+        public string? Value { get; }
+    }
+}

--- a/HtmlBuilder/Maroontress/Html/Impl/BaseTagImpl.cs
+++ b/HtmlBuilder/Maroontress/Html/Impl/BaseTagImpl.cs
@@ -1,0 +1,71 @@
+namespace Maroontress.Html.Impl
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using StyleChecker.Annotations;
+
+    /// <summary>
+    /// Abstraction of Tag and EmptyTag.
+    /// </summary>
+    /// <typeparam name="T">
+    /// The type of an HTML element.
+    /// </typeparam>
+    public abstract class BaseTagImpl<T> : AbstractNode, BaseTag<T>
+        where T : BaseTag<T>
+    {
+        /// <inheritdoc/>
+        public abstract string Name { get; }
+
+        /// <inheritdoc/>
+        public T AddAttributes(
+            params (string name, string? value)[] attributes)
+            => CreateAddingAttributes(attributes);
+
+        /// <inheritdoc/>
+        public T AddClass(params string[] values)
+            => Create(Attributes.GetAddingClassModifier(values));
+
+        /// <inheritdoc/>
+        public T AddEmptyAttributes(params string[] attributeNames)
+        {
+            static (string name, string? value) ToTuples(string name)
+                => (name, value: null);
+
+            return CreateAddingAttributes(attributeNames.Select(ToTuples));
+        }
+
+        /// <inheritdoc/>
+        public T WithClass(params string[] values)
+            => Create(Attributes.GetReplacingClassModifier(values));
+
+        /// <inheritdoc/>
+        public T WithId(string id)
+            => Create(Attributes.GetReplacingIdModifier(id));
+
+        /// <summary>
+        /// Gets a new element with the modifying function.
+        /// </summary>
+        /// <param name="modify">
+        /// The function that takes the data and returns the modified data.
+        /// </param>
+        /// <returns>
+        /// A new element.
+        /// </returns>
+        protected abstract T Create(Func<TagStruct, TagStruct> modify);
+
+        /// <summary>
+        /// Gets a new element with adding the specified attributes.
+        /// </summary>
+        /// <param name="attributes">
+        /// Tuples of the name and value representing an attribute. If the
+        /// value of the tuple is <c>null</c>, it represents the empty
+        /// attribute.
+        /// </param>
+        /// <returns>
+        /// A new element.
+        /// </returns>
+        protected abstract T CreateAddingAttributes(
+            IEnumerable<(string name, string? value)> attributes);
+    }
+}

--- a/HtmlBuilder/Maroontress/Html/Impl/Elements.cs
+++ b/HtmlBuilder/Maroontress/Html/Impl/Elements.cs
@@ -36,7 +36,7 @@ namespace Maroontress.Html.Impl
             {
                 Name = string.Intern(name.ToLowerInvariant()),
                 Children = ImmutableList<Node>.Empty,
-                Attributes = ImmutableDictionary<string, string>.Empty,
+                Attributes = ImmutableDictionary<string, AttributeData>.Empty,
                 Classes = ImmutableList<string>.Empty,
                 Id = null,
             };

--- a/HtmlBuilder/Maroontress/Html/Impl/EmptyTagImpl.cs
+++ b/HtmlBuilder/Maroontress/Html/Impl/EmptyTagImpl.cs
@@ -1,11 +1,14 @@
 namespace Maroontress.Html.Impl
 {
     using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using StyleChecker.Annotations;
 
     /// <summary>
     /// The default implementation of empty <see cref="EmptyTag"/>s.
     /// </summary>
-    public sealed class EmptyTagImpl : AbstractNode, EmptyTag
+    public sealed class EmptyTagImpl : BaseTagImpl<EmptyTag>, EmptyTag
     {
         private readonly TagStruct data;
 
@@ -36,29 +39,7 @@ namespace Maroontress.Html.Impl
         }
 
         /// <inheritdoc/>
-        public string Name => data.Name;
-
-        /// <inheritdoc/>
-        public EmptyTag AddAttributes(
-            params (string name, string value)[] attributes)
-            => new EmptyTagImpl(
-                this,
-                Attributes.GetAddingModifier(
-                    data.Attributes.ContainsKey, attributes));
-
-        /// <inheritdoc/>
-        public EmptyTag AddClass(params string[] values)
-            => new EmptyTagImpl(
-                this, Attributes.GetAddingClassModifier(values));
-
-        /// <inheritdoc/>
-        public EmptyTag WithClass(params string[] values)
-            => new EmptyTagImpl(
-                this, Attributes.GetReplacingClassModifier(values));
-
-        /// <inheritdoc/>
-        public EmptyTag WithId(string id)
-            => new EmptyTagImpl(this, Attributes.GetReplacingIdModifier(id));
+        public override string Name => data.Name;
 
         /// <inheritdoc/>
         public override void Accept(NodeVisitor visitor)
@@ -66,5 +47,19 @@ namespace Maroontress.Html.Impl
 
         /// <inheritdoc/>
         protected override NodeKind GetKind() => NodeKind.EmptyTag;
+
+        /// <inheritdoc/>
+        protected override EmptyTag Create(Func<TagStruct, TagStruct> modify)
+        {
+            return new EmptyTagImpl(this, modify);
+        }
+
+        /// <inheritdoc/>
+        protected override EmptyTag CreateAddingAttributes(
+            IEnumerable<(string name, string? value)> attributes)
+        {
+            return Create(Attributes.GetAddingModifier(
+                data.Attributes.ContainsKey, attributes));
+        }
     }
 }

--- a/HtmlBuilder/Maroontress/Html/Impl/TagImpl.cs
+++ b/HtmlBuilder/Maroontress/Html/Impl/TagImpl.cs
@@ -9,7 +9,7 @@ namespace Maroontress.Html.Impl
     /// The default implementation of <see cref="Tag"/>s other than void
     /// elements.
     /// </summary>
-    public sealed class TagImpl : AbstractNode, Tag
+    public sealed class TagImpl : BaseTagImpl<Tag>, Tag
     {
         private readonly TagStruct data;
 
@@ -39,7 +39,7 @@ namespace Maroontress.Html.Impl
         }
 
         /// <inheritdoc/>
-        public string Name => data.Name;
+        public override string Name => data.Name;
 
         /// <inheritdoc/>
         public Tag Add(IEnumerable<Node> children)
@@ -59,30 +59,24 @@ namespace Maroontress.Html.Impl
             => Add(new TextImpl(text));
 
         /// <inheritdoc/>
-        public Tag AddAttributes(
-            params (string name, string value)[] attributes)
-            => new TagImpl(
-                this,
-                Attributes.GetAddingModifier(
-                    data.Attributes.ContainsKey, attributes));
-
-        /// <inheritdoc/>
-        public Tag AddClass(params string[] values)
-            => new TagImpl(this, Attributes.GetAddingClassModifier(values));
-
-        /// <inheritdoc/>
-        public Tag WithClass(params string[] values)
-            => new TagImpl(this, Attributes.GetReplacingClassModifier(values));
-
-        /// <inheritdoc/>
-        public Tag WithId(string id)
-            => new TagImpl(this, Attributes.GetReplacingIdModifier(id));
-
-        /// <inheritdoc/>
         public override void Accept(NodeVisitor visitor)
             => visitor.VisitTag(in data);
 
         /// <inheritdoc/>
         protected override NodeKind GetKind() => NodeKind.Tag;
+
+        /// <inheritdoc/>
+        protected override Tag Create(Func<TagStruct, TagStruct> modify)
+        {
+            return new TagImpl(this, modify);
+        }
+
+        /// <inheritdoc/>
+        protected override Tag CreateAddingAttributes(
+            IEnumerable<(string name, string? value)> attributes)
+        {
+            return Create(Attributes.GetAddingModifier(
+                data.Attributes.ContainsKey, attributes));
+        }
     }
 }

--- a/HtmlBuilder/Maroontress/Html/Impl/TextWriterVisitor.cs
+++ b/HtmlBuilder/Maroontress/Html/Impl/TextWriterVisitor.cs
@@ -1,5 +1,6 @@
 namespace Maroontress.Html.Impl
 {
+    using System;
     using System.Collections.Generic;
     using System.Collections.Immutable;
     using System.IO;
@@ -66,13 +67,29 @@ namespace Maroontress.Html.Impl
                 }
                 Write("\"");
             }
-            foreach (var pair in tag.Attributes)
+            var values = tag.Attributes
+                .Values
+                .ToArray();
+            Array.Sort(values, (e1, e2) => e1.Order.CompareTo(e2.Order));
+
+            void WriteAttributeData(AttributeData data)
             {
                 Write(" ");
-                Write(pair.Key);
+                Write(data.Name);
+
+                var v = data.Value;
+                if (v is null)
+                {
+                    return;
+                }
                 Write("=\"");
-                WriteAttribute(pair.Value);
+                WriteAttribute(v);
                 Write("\"");
+            }
+
+            foreach (var data in values)
+            {
+                WriteAttributeData(data);
             }
             Write(">");
         }

--- a/HtmlBuilder/Maroontress/Html/TagStruct.cs
+++ b/HtmlBuilder/Maroontress/Html/TagStruct.cs
@@ -21,7 +21,7 @@ namespace Maroontress.Html
         /// Gets or sets the attributes of the tag (except <c>class</c> and
         /// <c>id</c> attribute).
         /// </summary>
-        public ImmutableDictionary<string, string> Attributes
+        public ImmutableDictionary<string, AttributeData> Attributes
         { get; set; }
 
         /// <summary>

--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ var html = nodeOf.Html.Add(
 var result = html.ToString();
 ```
 
+### Attributes
+
 The HTML attributes also can be manipulated as follows:
 
 ```csharp
@@ -44,6 +46,26 @@ The string `result` represents as follows:
 
 ```html
 <pre lang="csharp">var list = new List&lt;string&gt;();</pre>
+```
+
+The empty attribute can be generated as follows:
+
+```csharp
+var nodeOf = Nodes.NewFactory();
+var div = nodeOf.Div
+    .Add(nodeOf.Input.AddEmptyAttributes("disabled"))
+    // Or, specify null to the value.
+    .Add(nodeOf.Button.AddAttributes(("disabled", null)));
+var result = div.ToString();
+```
+
+The string `result` represents as follows:
+
+```html
+<div>
+  <input disabled>
+  <button disabled></button>
+</div>
 ```
 
 Note that the `id` and `class` attributes are treated specially as follows:
@@ -111,7 +133,7 @@ The string `result` represents as follows:
 
 ### How to get started
 
-```bash
+```plaintext
 git clone URL
 cd HtmlBuilder
 dotnet restore
@@ -120,7 +142,7 @@ dotnet build
 
 ### How to get test coverage report with Coverlet
 
-```bash
+```plaintext
 dotnet test -p:CollectCoverage=true -p:CoverletOutputFormat=opencover \
         --no-build HtmlBuilder.Test
 dotnet ANYWHERE/reportgenerator.dll \


### PR DESCRIPTION
- Generate the empty attribute with BaseTag<T>.AddAttributes() when
  the value is null.
- Add BaseTag<T>.AddEmptyAttributes() method.
- Refactor.